### PR TITLE
Python 3 support

### DIFF
--- a/pgmpl/__init__.py
+++ b/pgmpl/__init__.py
@@ -14,9 +14,9 @@ import pyqtgraph as pg
 from matplotlib import rcParams
 
 # pgmpl imports
-from info import *  # Defines __version__, etc.
-from util import printd
-from translate import color_translator
+from pgmpl.info import *  # Defines __version__, etc.
+from pgmpl.util import printd
+from pgmpl.translate import color_translator
 
 __all__ = ['figure', 'axes', 'pyplot', 'translate', 'text', 'util']
 

--- a/pgmpl/__init__.py
+++ b/pgmpl/__init__.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 # GUI imports
-from PyQt4 import QtGui
+from pyqtgraph import QtGui
 
 # Plotting imports
 import pyqtgraph as pg

--- a/pgmpl/axes.py
+++ b/pgmpl/axes.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 
 # pgmpl
 # noinspection PyUnresolvedReferences
-import __init__  # __init__ does setup stuff like making sure a QApp exists
+import pgmpl.__init__  # __init__ does setup stuff like making sure a QApp exists
 from pgmpl.translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
 from pgmpl.legend import Legend
 from pgmpl.util import printd, tolist, is_numeric

--- a/pgmpl/axes.py
+++ b/pgmpl/axes.py
@@ -24,11 +24,11 @@ from collections import defaultdict
 # pgmpl
 # noinspection PyUnresolvedReferences
 import __init__  # __init__ does setup stuff like making sure a QApp exists
-from translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
-from legend import Legend
-from util import printd, tolist, is_numeric
-from text import Text
-from contour import QuadContourSet
+from pgmpl.translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
+from pgmpl.legend import Legend
+from pgmpl.util import printd, tolist, is_numeric
+from pgmpl.text import Text
+from pgmpl.contour import QuadContourSet
 
 
 class Axes(pg.PlotItem):

--- a/pgmpl/colorbar.py
+++ b/pgmpl/colorbar.py
@@ -20,8 +20,8 @@ import numpy as np
 import pyqtgraph as pg
 
 # pgmpl
-import __init__
-from util import printd, tolist
+import pgmpl.__init__
+from pgmpl.util import printd, tolist
 
 
 class ColorbarBase(object):

--- a/pgmpl/contour.py
+++ b/pgmpl/contour.py
@@ -23,8 +23,8 @@ from pyqtgraph import functions as fn
 # pgmpl
 # noinspection PyUnresolvedReferences
 import __init__  # __init__ does setup stuff like making sure a QApp exists
-from translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
-from util import printd, tolist, is_numeric
+from pgmpl.translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
+from pgmpl.util import printd, tolist, is_numeric
 
 
 class ContourSet(object):

--- a/pgmpl/contour.py
+++ b/pgmpl/contour.py
@@ -22,7 +22,7 @@ from pyqtgraph import functions as fn
 
 # pgmpl
 # noinspection PyUnresolvedReferences
-import __init__  # __init__ does setup stuff like making sure a QApp exists
+import pgmpl.__init__  # __init__ does setup stuff like making sure a QApp exists
 from pgmpl.translate import plotkw_translator, color_translator, setup_pen_kw, color_map_translator, dealias
 from pgmpl.util import printd, tolist, is_numeric
 

--- a/pgmpl/figure.py
+++ b/pgmpl/figure.py
@@ -22,11 +22,11 @@ from matplotlib import rcParams
 
 # pgmpl
 # noinspection PyUnresolvedReferences
-import __init__  # __init__ does setup stuff like making sure a QApp exists
-from tracking import tracker
-from axes import Axes
-from util import printd, tolist
-from colorbar import Colorbar
+import pgmpl.__init__  # __init__ does setup stuff like making sure a QApp exists
+from pgmpl.tracking import tracker
+from pgmpl.axes import Axes
+from pgmpl.util import printd, tolist
+from pgmpl.colorbar import Colorbar
 
 
 class Figure(pg.PlotWidget):

--- a/pgmpl/legend.py
+++ b/pgmpl/legend.py
@@ -21,8 +21,8 @@ import pyqtgraph as pg
 
 # pgmpl
 # noinspection PyUnresolvedReferences
-import __init__  # __init__ does setup stuff like making sure a QApp exists
-from util import printd, tolist, is_numeric
+import pgmpl.__init__  # __init__ does setup stuff like making sure a QApp exists
+from pgmpl.util import printd, tolist, is_numeric
 
 
 class Legend:

--- a/pgmpl/pyplot.py
+++ b/pgmpl/pyplot.py
@@ -12,10 +12,10 @@ from __future__ import print_function, division
 import numpy as np
 
 # pgmpl
-from tracking import tracker
-from figure import Figure
-from axes import Axes
-from util import printd
+from pgmpl.tracking import tracker
+from pgmpl.figure import Figure
+from pgmpl.axes import Axes
+from pgmpl.util import printd
 
 
 def figure(*args, **kwargs):

--- a/pgmpl/text.py
+++ b/pgmpl/text.py
@@ -14,7 +14,7 @@ import warnings
 
 # Plotting imports
 import pyqtgraph as pg
-from translate import color_translator, dealias
+from pgmpl.translate import color_translator, dealias
 
 
 class Text(pg.TextItem):

--- a/pgmpl/tracking.py
+++ b/pgmpl/tracking.py
@@ -10,7 +10,7 @@ from __future__ import print_function, division
 import warnings
 
 # pgmpl
-from util import printd
+from pgmpl.util import printd
 
 
 class WTracker:

--- a/pgmpl/tracking.py
+++ b/pgmpl/tracking.py
@@ -34,5 +34,9 @@ class WTracker:
     def status(self):
         printd('  {} tracked windows = {}'.format(len(self.open_windows), self.open_windows))
 
+    def close_all(self):
+        while len(self.open_windows):
+            self.open_windows[0].close()
+
 
 tracker = WTracker()

--- a/pgmpl/translate.py
+++ b/pgmpl/translate.py
@@ -15,7 +15,7 @@ import copy
 import numpy as np
 
 # Plotting imports
-from PyQt4 import QtCore
+from pyqtgraph import QtCore
 import pyqtgraph as pg
 import matplotlib.cm
 from matplotlib import rcParams

--- a/pgmpl/translate.py
+++ b/pgmpl/translate.py
@@ -49,12 +49,12 @@ def dealias(**kws):
         'verticalalignment': ['va'],
         'horizontalalignment': ['ha'],
     }
-    for primary, aliases in alias_lists.iteritems():
+    for primary, aliases in list(alias_lists.items()):
         aliasv = {alias: kws.pop(alias, missing_value_mark) for alias in aliases}
         not_missing = [v != missing_value_mark for v in aliasv.values()]
         if primary not in kws.keys() and any(not_missing):
             # The aliases only need be considered if the primary is missing.
-            aliasu = np.atleast_1d(aliasv.keys())[np.atleast_1d(not_missing)][0]
+            aliasu = np.atleast_1d(list(aliasv.keys()))[np.atleast_1d(not_missing)][0]
             kws[primary] = aliasv[aliasu]
             printd("  assigned kws['{}'] = kws.pop('{}')".format(primary, aliasu))
         else:

--- a/pgmpl/translate.py
+++ b/pgmpl/translate.py
@@ -49,7 +49,7 @@ def dealias(**kws):
         'verticalalignment': ['va'],
         'horizontalalignment': ['ha'],
     }
-    for primary, aliases in list(alias_lists.items()):
+    for primary, aliases in list(alias_lists.items()):  # https://stackoverflow.com/a/13998534/6605826
         aliasv = {alias: kws.pop(alias, missing_value_mark) for alias in aliases}
         not_missing = [v != missing_value_mark for v in aliasv.values()]
         if primary not in kws.keys() and any(not_missing):

--- a/pgmpl/translate.py
+++ b/pgmpl/translate.py
@@ -27,7 +27,7 @@ except ImportError:  # Older Matplotlib versions were organized differently
     to_rgba = colorConverter.to_rgba
 
 # pgmpl imports
-from util import set_debug, printd, tolist
+from pgmpl.util import set_debug, printd, tolist
 
 
 def dealias(**kws):

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -74,10 +74,10 @@ def demo_plot():
     axs[1, 1].errorbar(-x[40:45], y1[40:45], y1[40:45] * 0.1, x[40:45] * 0.05, color='g', xuplims=True, xlolims=True)
 
     axs[2, 0].plot(x, y1, color='m', marker='o', label='y1 purple circles')
-    axs[2, 0].scatter([0, 2, 4, 6, 8, 10], [80, 40, 90, 10, 20, 05], c=['r', 'b', 'g', 'k', 'm', 'y'], linewidths=1)
+    axs[2, 0].scatter([0, 2, 4, 6, 8, 10], [80, 40, 90, 10, 20, 5], c=['r', 'b', 'g', 'k', 'm', 'y'], linewidths=1)
     axs[2, 0].scatter(x, x*0+60, c=x, marker='v', s=4, edgecolors=' ')
     axs[2, 0].scatter(x, x*0+50, c=x, marker='s', s=5, cmap='plasma', linewidths=0)
-    axs[2, 0].scatter([0, 2, 4, 6, 8, 10], [50, 90, 80, 00, 50, 90], c=[90, 0, 50, 20, 75, 66],
+    axs[2, 0].scatter([0, 2, 4, 6, 8, 10], [50, 90, 80, 0, 50, 90], c=[90, 0, 50, 20, 75, 66],
                       marker='^', linewidths=2, edgecolors='r')
     axs[2, 0].scatter(x, x*0-10, c=x, cmap='jet', marker=None,
                       verts=[(0, 0), (0.5, 0.5), (0, 0.5), (-0.5, 0), (0, -0.5), (0.5, -0.5)])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -54,6 +54,12 @@ class TestPgmplTracking(unittest.TestCase):
         self.printv('      test_tracker_warnings: called window_closed with a nonsense window to trigger a warning  '
                     'and got {}/{} warnings.'.format(len(w), warnings_expected))
 
+    def test_close_all(self):
+        dummy = 'dummy_window'
+        tracker.window_opened(dummy)
+        tracker.close_all()
+        assert len(tracke.open_windows) == 0
+
     def setUp(self):
         test_id = self.id()
         test_name = '.'.join(test_id.split('.')[-2:])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -28,6 +28,7 @@ class TestPgmplTracking(unittest.TestCase):
 
     def test_tracker(self):
         assert isinstance(tracker, WTracker)
+        tracker.close_all()
         dummy = 'dummy_window'
         open_windows0 = copy.deepcopy(tracker.open_windows)
         tracker.window_opened(dummy)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -16,6 +16,7 @@ import warnings
 # pgmpl
 from pgmpl import __init__  # __init__ does setup stuff like making sure a QApp exists
 from pgmpl.tracking import WTracker, tracker
+from pgmpl.figure import Figure
 
 
 class TestPgmplTracking(unittest.TestCase):
@@ -55,10 +56,9 @@ class TestPgmplTracking(unittest.TestCase):
                     'and got {}/{} warnings.'.format(len(w), warnings_expected))
 
     def test_close_all(self):
-        dummy = 'dummy_window'
-        tracker.window_opened(dummy)
+        Figure()
         tracker.close_all()
-        assert len(tracke.open_windows) == 0
+        assert len(tracker.open_windows) == 0
 
     def setUp(self):
         test_id = self.id()

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -10,7 +10,7 @@ from __future__ import print_function, division
 import os
 import unittest
 import numpy as np
-from PyQt4 import QtCore, QtGui
+from pyqtgraph import QtCore, QtGui
 import copy
 from matplotlib import rcParams
 


### PR DESCRIPTION
Description:
- Import PyQt stuff through pyqtgraph, which already handles PyQt4 vs PyQt5 for python 2 vs 3
- Partial progress toward #53
- Can't fully support yet because pyqtgraph 0.10.0 has a bug with python 3.6 but not 2.7. This has been fixed on the development branch of pyqtgraph, so just wait for the next version.

Pre-merge checklist (in addition to automatic checks):
- [x] Author has reviewed and finalized code
- [skip] New functions, classes, and keywords are described in docstrings
  - new method is so small and self explanatory that I'm skipping docstring
- [x] This pull request is ready for review / merge
